### PR TITLE
fix: add dummy README to fix installation issues

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+Refer to README.md


### PR DESCRIPTION
Currently we cannot install the package directly using "zkg install https://github.com/DINA-community/icsnpp-acse", because the compilation try to find README (not README.md) file. In here, I created dummy README to fix that issue.